### PR TITLE
Correct use of Unwrap return value to determine success

### DIFF
--- a/libraries/support/packetcomm.cpp
+++ b/libraries/support/packetcomm.cpp
@@ -145,7 +145,7 @@ namespace Cosmos {
             {
                 return false;
             }
-            return Unwrap(checkcrc);
+            return (Unwrap(checkcrc) >= 0);
         }
 
         bool PacketComm::ASMUnPacketize()
@@ -194,7 +194,7 @@ namespace Cosmos {
             Ax25Handle axhandle;
             axhandle.unstuff(packetized);
             wrapped = axhandle.ax25_packet;
-            return Unwrap(checkcrc);
+            return (Unwrap(checkcrc) >= 0);
         }
 
         bool PacketComm::AX25UnPacketize(bool checkcrc)
@@ -206,7 +206,7 @@ namespace Cosmos {
             if (iretn >= 0)
             {
                 wrapped = axhandle.get_data();
-                return Unwrap(checkcrc);
+                return (Unwrap(checkcrc) >= 0);
             }
             else
             {


### PR DESCRIPTION
Previously, `SLIPUnpacketize()` and other "unpacketize" functions would convert the return value from `Unwrap()` directly to a boolean. This is incorrect, as Unwrap returns a negative value if there is an error, otherwise it returns the data size. So it would fail on valid packets with no data, but report success on actual errors. The correct way to interpret whether a call to Unwrap was successful is to return `Unwrap() >= 0`.